### PR TITLE
Update map.html attributionControl is false by default to show custom text

### DIFF
--- a/_includes/map.html
+++ b/_includes/map.html
@@ -13,7 +13,8 @@
         center: [31.421, 48.600],
         zoom: 5.3,
         container: 'map',
-        antialias: true
+        antialias: true,
+        attributionControl: false
     });
     map.addControl(new maplibregl.FullscreenControl(), 'top-left');
     


### PR DESCRIPTION
Для того, щоб у поточній версії `maplibre gl` додати власну атрибуцію на мапу потрібно спочатку явно відключити attributionControl і вже далі додати цей контрол з власним текстом атрибуції.